### PR TITLE
Add MTG to the list of supported games

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -2,3 +2,4 @@ name = xp
 title = XP
 description = An experience system (XP) with shop, rewards, levels, and much more.
 optional_depends = default, wool, farming, doors, bucket, carts, fire, xpanes, unified_inventory, mobs_bat, spawners_mobs, legendary_ore, rainbow_ore, moreores, lapis, atium, mobs_monster
+supported_games = minetest_game


### PR DESCRIPTION
Things added/changed:

- Add MTG to the list of supported games.
  - If the mod works fine on all games, we can simply use `*` instead.
